### PR TITLE
fix: missing underscore in reloading var

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -156,7 +156,7 @@ export default {
       if (this._reloading) {
         return
       }
-      this.reloading = true
+      this._reloading = true
 
       // Stop timers
       this.clearTimeout()


### PR DESCRIPTION
Small typo