### PR TITLE
fix: set `Content-Type` of for index page

### DIFF
--- a/lib/loading.js
+++ b/lib/loading.js
@@ -2,7 +2,7 @@ const { resolve } = require('path')
 const connect = require('connect')
 const serveStatic = require('serve-static')
 const fs = require('fs-extra')
-const { json, end } = require('node-res')
+const { json, end, header } = require('node-res')
 
 const SSE = require('./sse')
 
@@ -70,6 +70,7 @@ class LoadingUI {
       .replace('{STATE}', JSON.stringify(this.state))
       .replace(/{BASE_URL}/g, this.baseURL)
 
+    header(res, 'Content-Type', 'text/html')
     end(res, html)
   }
 }


### PR DESCRIPTION
Explicitly set content-type header on the index response.
That header fell out (accidentally, I presume) during switching to EventSource
(68ea10e321768fbca24e079bdbcaf5c51d2f5c0b).