### PR TITLE
feat: prevent endless reloading

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -25,15 +25,13 @@
     <div v-else-if="preventReload" class="reload_prevented">
       <h3 class="hasErrors">Failed to show Nuxt.js app after {{ maxReloadCount }} reloads</h3>
       <p>
-        Your Nuxt.js app could not be shown after {{ maxReloadCount }} reloads
-        even though the webpack build appears to have finished.
+        Your Nuxt.js app could not be shown even though the webpack build appears to have finished.
       </p>
       <p>
-        Try to reload the page manually, if this problem persist try to restart your Nuxt.js dev server.
+        Try to reload the page manually, if this problem persists try to restart your Nuxt.js dev server.
       </p>
     </div>
     <transition-group v-else>
-      WHY
       <div v-for="bundle of bundles" :key="bundle" class="row">
         <h3>{{ bundle | capitalize }} bundle</h3>
         <div class="progress_bar_container">
@@ -227,7 +225,7 @@ export default {
       this.updateReloadItems()
 
       // Reload the page
-      window.location.reload()
+      window.location.reload(true)
     }
   }
 }

--- a/app/app.vue
+++ b/app/app.vue
@@ -183,10 +183,14 @@ export default {
       const lastReloadTime = parseInt(this.retrieveItem('lastReloadTime')) || 0
 
       const currentTime = new Date().getTime()
-      if (reloadCount > this.maxReloadCount && currentTime < 1000 + lastReloadTime) {
+      const canReload = reloadCount < this.maxReloadCount
+      const reloadWasOutsideThreshold = lastReloadTime && currentTime > 1000 + lastReloadTime
+
+      if (!canReload || reloadWasOutsideThreshold) {
         this.removeItem('reloadCount')
         this.removeItem('lastReloadTime')
-        return false
+
+        return canReload
       }
 
       this.storeItem('reloadCount', 1 + reloadCount)

--- a/app/css/loading.css
+++ b/app/css/loading.css
@@ -54,6 +54,15 @@ h4 {
   color: #383838;
 }
 
+.reload_prevented {
+  width: 500px;
+  max-width: 85vw;
+}
+
+.reload_prevented p {
+  margin-bottom: 1rem;
+}
+
 .progress_bar_container {
   background-color: #DDDDDD;
   border-radius: 6px;

--- a/app/mixins/storage.js
+++ b/app/mixins/storage.js
@@ -1,0 +1,25 @@
+const baseKey = '__nuxt_loading_screen_'
+
+export default {
+  methods: {
+    createItemKey (key) {
+      return `${baseKey}${key}`
+    },
+
+    storeItem (key, value) {
+      try {
+        sessionStorage.setItem(this.createItemKey(key), `${value}`)
+      } catch (err) {
+        console.error(err)
+      }
+    },
+
+    retrieveItem (key) {
+      return sessionStorage.getItem(this.createItemKey(key))
+    },
+
+    removeItem (key) {
+      sessionStorage.removeItem(this.createItemKey(key))
+    }
+  }
+}


### PR DESCRIPTION
When somehow the nuxt app can not be shown, the loading screen would keep endlessly reloading.

I think that in almost any case when this issue happens the user has hit a webpack issue. This feature is in no means a fix for anything, it just prevents possible developer confusion as its difficult to understand why the reloading occurs as probably almost nobody knows that the nuxt loading screen does this reloading.