### PR TITLE
Configurable Server Middleware Path

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -12,6 +12,7 @@ module.exports = function NuxtLoadingScreen () {
   const options = this.options.build.loadingScreen = defu(this.options.build.loadingScreen, {
     baseURL,
     baseURLAlt: baseURL,
+    middlewarePath: '/_loading',
     altPort: false,
     image: undefined,
     colors: {}
@@ -20,7 +21,7 @@ module.exports = function NuxtLoadingScreen () {
   const loading = new LoadingUI(options)
 
   nuxt.options.serverMiddleware.push({
-    path: '/_loading',
+    path: options.middlewarePath,
     handler: (req, res) => { loading.app(req, res) }
   })
 


### PR DESCRIPTION
- #85 
- adds middlewarePath default as '/_loading'
- uses options.middlewarePath for the path of the middleware that is
  pushed onto the nuxt serverMiddleware stack

Very much open to feedback on this as I am new to the codebase.